### PR TITLE
Empty search SQL

### DIFF
--- a/src/Hook/Posts.php
+++ b/src/Hook/Posts.php
@@ -75,6 +75,10 @@ final class Posts
 
             $searches = array_filter($searches);
 
+            if (count($searches) === 0) {
+                continue;
+            }
+
             $search = '(' . implode($or, $searches) . ')' . $or;
 
             $clause = preg_replace('/' . $or . '/', $or . $search, $clause, 1);

--- a/tests/Search/Hook/PostsTest.php
+++ b/tests/Search/Hook/PostsTest.php
@@ -165,7 +165,6 @@ final class PostsTest extends TestCase
 
         $fakeTermIds = [];
         $searchTerms = ['Testterm', 'AnotherQuery'];
-        $expectations = ['OR ()'];
 
         $this->wpdb->shouldReceive('esc_like')
             ->times(count($searchTerms))
@@ -185,9 +184,7 @@ final class PostsTest extends TestCase
 
         $result = $this->search(['Testman', 'theTester'], new Posts($dimensions));
 
-        foreach ($expectations as $expectation) {
-            $this->assertContains($expectation, $result);
-        }
+        $this->assertNotContains('OR ()', $result);
     }
 
     private function search(array $searchTerms, Posts $posts = null)

--- a/tests/Search/Hook/PostsTest.php
+++ b/tests/Search/Hook/PostsTest.php
@@ -112,7 +112,9 @@ final class PostsTest extends TestCase
 
     public function testSearch()
     {
-        $this->search();
+        $searchTerms = ['Testman', 'theTester'];
+
+        $this->search($searchTerms);
     }
 
     public function testSearchWithoutSearch()
@@ -123,12 +125,11 @@ final class PostsTest extends TestCase
         $this->assertEquals($expectation, $result);
     }
 
-    private function search()
+    private function search(array $searchTerms)
     {
         $and = " AND ";
         $or = " OR ";
 
-        $searchTerms = ['Testman', 'theTester'];
         $fakeTermIds = [1, 9];
         $baseSql = $and . "(";
 

--- a/tests/Search/Hook/PostsTest.php
+++ b/tests/Search/Hook/PostsTest.php
@@ -141,7 +141,11 @@ final class PostsTest extends TestCase
             ->times(count($searchTerms))
             ->andReturn($fakeTermIds);
 
-        $this->search($searchTerms, $expectations);
+        $result = $this->search($searchTerms);
+
+        foreach ($expectations as $expectation) {
+            $this->assertContains($expectation, $result);
+        }
     }
 
     public function testSearchWithoutSearch()
@@ -179,10 +183,14 @@ final class PostsTest extends TestCase
             ->times(count($searchTerms))
             ->andReturn($fakeTermIds);
 
-        $this->search(['Testman', 'theTester'], $expectations, new Posts($dimensions));
+        $result = $this->search(['Testman', 'theTester'], new Posts($dimensions));
+
+        foreach ($expectations as $expectation) {
+            $this->assertContains($expectation, $result);
+        }
     }
 
-    private function search(array $searchTerms, array $expectations, Posts $posts = null)
+    private function search(array $searchTerms, Posts $posts = null)
     {
         if (! $posts) {
             $posts = $this->posts;
@@ -204,11 +212,7 @@ final class PostsTest extends TestCase
         $baseSql = mb_substr($baseSql, 0, mb_strlen($baseSql) - mb_strlen($or));
         $baseSql .= ")";
 
-        $result = $posts->search($baseSql, $this->getQuery(true, $searchTerms));
-
-        foreach ($expectations as $expectation) {
-            $this->assertContains($expectation, $result);
-        }
+        return $posts->search($baseSql, $this->getQuery(true, $searchTerms));
     }
 
     private function getQuery($isSearch = true, $terms = ['Testman', 'mcTest'])

--- a/tests/Search/Hook/PostsTest.php
+++ b/tests/Search/Hook/PostsTest.php
@@ -112,6 +112,19 @@ final class PostsTest extends TestCase
 
     public function testSearch()
     {
+        $this->search();
+    }
+
+    public function testSearchWithoutSearch()
+    {
+        $expectation = '';
+        $result = $this->posts->search('', $this->getQuery(false));
+
+        $this->assertEquals($expectation, $result);
+    }
+
+    private function search()
+    {
         $and = " AND ";
         $or = " OR ";
 
@@ -162,14 +175,6 @@ final class PostsTest extends TestCase
         foreach ($expectations as $expectation) {
             $this->assertContains($expectation, $result);
         }
-    }
-
-    public function testSearchWithoutSearch()
-    {
-        $expectation = '';
-        $result = $this->posts->search('', $this->getQuery(false));
-
-        $this->assertEquals($expectation, $result);
     }
 
     private function getQuery($isSearch = true, $terms = ['Testman', 'mcTest'])

--- a/tests/Search/Hook/PostsTest.php
+++ b/tests/Search/Hook/PostsTest.php
@@ -166,7 +166,6 @@ final class PostsTest extends TestCase
                 return $sql;
             });
 
-
         $this->wpdb->shouldReceive('get_col')
             ->times(count($searchTerms))
             ->andReturn($fakeTermIds);

--- a/tests/Search/Hook/PostsTest.php
+++ b/tests/Search/Hook/PostsTest.php
@@ -134,8 +134,24 @@ final class PostsTest extends TestCase
         $this->assertEquals($expectation, $result);
     }
 
-    private function search(array $searchTerms, array $expectations, array $fakeTermIds)
+    public function testSearchWithoutTermHit()
     {
+        $dimensions = new Dimensions();
+        $dimensions->add(new Term($this->wpdb, [
+            'taxonomy' => $this->taxonomy,
+        ]));
+
+        $expectations = [' '];
+
+        $this->search(['Testman', 'theTester'], $expectations, [], new Posts($dimensions));
+    }
+
+    private function search(array $searchTerms, array $expectations, array $fakeTermIds, Posts $posts = null)
+    {
+        if (! $posts) {
+            $posts = $this->posts;
+        }
+
         $and = " AND ";
         $or = " OR ";
 
@@ -170,7 +186,7 @@ final class PostsTest extends TestCase
             ->times(count($searchTerms))
             ->andReturn($fakeTermIds);
 
-        $result = $this->posts->search($baseSql, $this->getQuery(true, $searchTerms));
+        $result = $posts->search($baseSql, $this->getQuery(true, $searchTerms));
 
         foreach ($expectations as $expectation) {
             $this->assertContains($expectation, $result);


### PR DESCRIPTION
Fixes wrong SQL output `OR ()` on empty searches (when Dimensions return empty SQL strings).